### PR TITLE
Remove code that is not necessary (duplicate requests & UI updates): …

### DIFF
--- a/IPSX/Common/RequestBuilder.swift
+++ b/IPSX/Common/RequestBuilder.swift
@@ -102,13 +102,6 @@ public class RequestBuilder: NSObject, URLSessionDelegate {
                 request = Request(url:url, httpMethod: "POST", contentType: ContentType.applicationJSON, body: body)
             }
             
-        case .enrollTestingDetails:
-            var url = Url.base + Url.enrollTestingArgs
-            if let params = urlParams as? [String: String] {
-                url = url.replaceKeysWithValues(paramsDict: params)
-                request = Request(url:url, httpMethod: "GET", contentType: ContentType.applicationJSON)
-            }
-            
         case .enrollStakingDetails:
             var url = Url.base + Url.enrollStakingArgs
             if let params = urlParams as? [String: String] {

--- a/IPSX/Common/RequestModel.swift
+++ b/IPSX/Common/RequestModel.swift
@@ -131,7 +131,6 @@ public enum IPRequestType: Int {
     case getTokenRequestList
     case enrollTesting
     case enrollStaking
-    case enrollTestingDetails
     case enrollStakingDetails
     case getSettings
     case updateSettings

--- a/IPSX/Flows/EnrolStaking/Controller/EnrolStakeSubscribeController.swift
+++ b/IPSX/Flows/EnrolStaking/Controller/EnrolStakeSubscribeController.swift
@@ -25,8 +25,7 @@ class EnrolStakeSubscribeController: UIViewController {
     var userInfo: UserInfo? { return UserManager.shared.userInfo }
     var ethAdresses: [EthAddress] = []
     var editMode = false
-    var enroledAddresses: [EthAddress]? = nil
-
+    var onDismiss: ((_ hasUpdatedStaking: Bool)->())?
     var selectedEths: [String]  {
         var selected: [String] = []
         if let selectedIndexPaths = tableView.indexPathsForSelectedRows {
@@ -124,7 +123,12 @@ class EnrolStakeSubscribeController: UIViewController {
                     if self.editMode {
                         UserInfoService().retrieveETHaddresses(completionHandler: { result in
                             switch result {
-                            case .success(let ethAddresses): UserManager.shared.ethAddresses = ethAddresses as? [EthAddress]
+                            case .success(let ethAddresses):
+                                UserManager.shared.ethAddresses = ethAddresses as? [EthAddress]
+                                DispatchQueue.main.async {
+                                    self.onDismiss?(true)
+                                }
+
                             case .failure(_): break
                             }
                             DispatchQueue.main.async {

--- a/IPSX/Flows/EnrolStaking/Controller/EnrolStakeSummaryController.swift
+++ b/IPSX/Flows/EnrolStaking/Controller/EnrolStakeSummaryController.swift
@@ -16,7 +16,6 @@ class EnrolStakeSummaryController: UIViewController {
     @IBOutlet weak var walletAddressLabel: UILabel!
     @IBOutlet weak var enrolmentDateLabel: UILabel!
     @IBOutlet weak var enrolmentTimeLabel: UILabel!
-    
     @IBOutlet weak var editButton: UIButton!
     @IBOutlet weak var loadingView: CustomLoadingView!
     @IBOutlet weak var topBarView: UIView!
@@ -26,7 +25,6 @@ class EnrolStakeSummaryController: UIViewController {
             topConstraint = topConstraintOutlet
         }
     }
-    
     var toast: ToastAlertView?
     var topConstraint: NSLayoutConstraint?
     var enroledAddresses: [EthAddress]? = nil
@@ -44,9 +42,10 @@ class EnrolStakeSummaryController: UIViewController {
     var enrollment: [(ethID: String, createdDate: Date)] = []
     
     override func viewDidLoad() {
+        
         super.viewDidLoad()
-
         editButton.isHidden = enroledAddresses == nil
+        enrollmentDetails()
     }
     
     override func viewDidLayoutSubviews() {
@@ -58,7 +57,6 @@ class EnrolStakeSummaryController: UIViewController {
         super.viewWillAppear(animated)
         NotificationCenter.default.addObserver(self, selector: #selector(reachabilityChanged(_:)), name: ReachabilityChangedNotification, object: nil)
         loadValidAddresses()
-        enrollmentDetails()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -70,7 +68,11 @@ class EnrolStakeSummaryController: UIViewController {
         if segue.identifier == "editStakingsSegueID" {
             let enrolController = segue.destination as? EnrolStakeSubscribeController
             enrolController?.editMode = true
-            enrolController?.enroledAddresses = self.enroledAddresses
+            enrolController?.onDismiss = { hasUpdatedStaking in
+                if hasUpdatedStaking {
+                    self.enrollmentDetails()
+                }
+            }
         }
     }
     

--- a/IPSX/Flows/EnrolTesting/Controller/EnrolTestSummaryController.swift
+++ b/IPSX/Flows/EnrolTesting/Controller/EnrolTestSummaryController.swift
@@ -10,7 +10,6 @@ import UIKit
 
 class EnrolTestSummaryController: UIViewController {
     
-    
     @IBOutlet weak var ethAddresAlias: UILabel!
     @IBOutlet weak var ethAddress: UILabel!
     @IBOutlet weak var enroledDate: UILabel!
@@ -37,9 +36,7 @@ class EnrolTestSummaryController: UIViewController {
     override func viewDidLoad() {
         
         super.viewDidLoad()
-        
         updateUI()
-        enrollmentDetails()
     }
     
     override func viewDidLayoutSubviews() {
@@ -70,38 +67,10 @@ class EnrolTestSummaryController: UIViewController {
     }
     
     private func updateUI() {
-        ethAddresAlias.text = enroledAddress?.alias
-        ethAddress.text     = enroledAddress?.address
+        ethAddresAlias.text = enroledAddress?.alias ?? "-"
+        ethAddress.text     = enroledAddress?.address ?? "-"
         enroledDate.text    = enroledAddress?.testingEnrollmentDate?.dateToString(format: "dd MMM yyyy") ?? "-- --- --"
         enroledTime.text    = enroledAddress?.testingEnrollmentDate?.dateToString(format: "HH:mm") ?? "--:--"
-    }
-    
-    func enrollmentDetails() {
-        
-        loadingView?.startAnimating()
-        EnrollmentService().getEnrollmentDetails(requestType: .enrollTestingDetails, completionHandler: { result in
-            
-            self.loadingView?.stopAnimating()
-            switch result {
-            case .success(let details):
-                if let details = details as? (String, Date) {
-                    let createdDate = details.1
-                    
-                    DispatchQueue.main.async {
-                        self.enroledDate.text = createdDate.dateToString(format: "dd MMM yyyy")
-                        self.enroledTime.text = createdDate.dateToString(format: "HH:mm")
-                    }
-                }
-                else {
-                    self.errorMessage = "Generic Error Message".localized
-                }
-
-            case .failure(let error):
-                self.handleError(error, requestType: .enrollTesting, completion: {
-                    self.enrollmentDetails()
-                })
-            }
-        })
     }
 }
 
@@ -111,26 +80,6 @@ extension EnrolTestSummaryController: ToastAlertViewPresentable {
         if self.toast == nil, let toastView = ToastAlertView(parentUnderView: parentUnderView, parentUnderViewConstraint: self.topConstraint!, alertText:text) {
             self.toast = toastView
             view.insertSubview(toastView, belowSubview: topBarView)
-        }
-    }
-}
-
-extension EnrolTestSummaryController: ErrorPresentable {
-    
-    func handleError(_ error: Error, requestType: IPRequestType, completion:(() -> ())? = nil) {
-        
-        switch error {
-            
-        case CustomError.expiredToken:
-            
-            LoginService().getNewAccessToken(errorHandler: { error in
-                self.errorMessage = "Generic Error Message".localized
-                
-            }, successHandler: {
-                completion?()
-            })
-        default:
-            self.errorMessage = "Generic Error Message".localized
         }
     }
 }

--- a/IPSX/Flows/Profile/Controller/ProfileViewController.swift
+++ b/IPSX/Flows/Profile/Controller/ProfileViewController.swift
@@ -184,11 +184,6 @@ class ProfileViewController: UIViewController {
         case "walletViewIdentifier":
             let addController = segue.destination as? AddWalletController
             addController?.ethereumAddress = selectedAddress
-            addController?.onDismiss = { hasUpdatedETH in
-                if hasUpdatedETH {
-                    self.retrieveETHaddresses()
-                }
-            }
             
         case "enrollTestingSummarySegueID":
             let summaryController = segue.destination as? EnrolTestSummaryController

--- a/IPSX/Flows/Register/Controller/AddWalletController.swift
+++ b/IPSX/Flows/Register/Controller/AddWalletController.swift
@@ -33,7 +33,6 @@ class AddWalletController: UIViewController {
     var topConstraint: NSLayoutConstraint?
     var ethereumAddress: EthAddress?
     var continueBottomDist: CGFloat = 0.0
-    var onDismiss: ((_ hasUpdatedETH: Bool)->())?
     var shouldPop = false
     
     private var fieldsStateDic: [String : Bool] = ["walletName" : true, "ethAddress" : false]
@@ -159,7 +158,6 @@ class AddWalletController: UIViewController {
             case .success(_):
                 
                 DispatchQueue.main.async {
-                    self.onDismiss?(true)
                     self.navigationController?.popViewController(animated: true)
                 }
                 
@@ -198,7 +196,6 @@ class AddWalletController: UIViewController {
                         UserManager.shared.ethAddresses = [ethAddress]
                     }
                     if self.shouldPop {
-                        self.onDismiss?(true)
                         self.navigationController?.popViewController(animated: true)
                     } else {
                         self.performSegue(withIdentifier: "showCongratsSegueID", sender: nil)

--- a/IPSX/Service/EnrollmentService.swift
+++ b/IPSX/Service/EnrollmentService.swift
@@ -78,59 +78,28 @@ class EnrollmentService {
                 return
             }
             
-            switch requestType {
-                
-            case .enrollTestingDetails:
-                
-                guard let jsonArray = JSON(data: data).array, jsonArray.count > 0 else {
-                    completionHandler(ServiceResult.failure(CustomError.invalidJson))
-                    return
-                }
-                
-                for json in jsonArray {
-                    
-                    let status        = json["status"].stringValue
-                    let ethId         = json["usereth_id"].stringValue
-                    let createdString = json["created_at"].stringValue
-                    let dateFormatter = DateFormatter.backendResponseParse()
-                    
-                    // Only one address can be accepted for Testing
-                    if status == "accepted", let createdDate = dateFormatter.date(from: createdString) {
-                        completionHandler(ServiceResult.success((ethId, createdDate)))
-                    }
-                    else {
-                        completionHandler(ServiceResult.failure(CustomError.invalidJson))
-                    }
-                }
-                
-            case .enrollStakingDetails:
-                
-                guard let jsonArray = JSON(data: data).array, jsonArray.count > 0 else {
-                    completionHandler(ServiceResult.failure(CustomError.invalidJson))
-                    return
-                }
-                
-                var enrollmentDetails: [(String, Date)] = []
-                
-                for json in jsonArray {
-                    
-                    let status        = json["status"].stringValue
-                    let ethId         = json["usereth_id"].stringValue
-                    let createdString = json["created_at"].stringValue
-                    let dateFormatter = DateFormatter.backendResponseParse()
-                    
-                    if status == "accepted", let createdDate = dateFormatter.date(from: createdString) {
-                        enrollmentDetails.append((ethId, createdDate))
-                    }
-                    else {
-                        completionHandler(ServiceResult.failure(CustomError.invalidJson))
-                    }
-                }
-                completionHandler(ServiceResult.success(enrollmentDetails))
-                
-            default:
-                break
+            guard let jsonArray = JSON(data: data).array, jsonArray.count > 0 else {
+                completionHandler(ServiceResult.failure(CustomError.invalidJson))
+                return
             }
+            
+            var enrollmentDetails: [(String, Date)] = []
+            
+            for json in jsonArray {
+                
+                let status        = json["status"].stringValue
+                let ethId         = json["usereth_id"].stringValue
+                let createdString = json["created_at"].stringValue
+                let dateFormatter = DateFormatter.backendResponseParse()
+                
+                if status == "accepted", let createdDate = dateFormatter.date(from: createdString) {
+                    enrollmentDetails.append((ethId, createdDate))
+                }
+                else {
+                    completionHandler(ServiceResult.failure(CustomError.invalidJson))
+                }
+            }
+            completionHandler(ServiceResult.success(enrollmentDetails))
         })
     }
 }


### PR DESCRIPTION
…testing enroll details not needed (we have the enrolledAddress passed through segue with all the details)

Removed onDismiss from Profile -> Edit (we are updating the data everytime on willAppear, so no need to track if hasUpdatedETH or not)
Adding flag for stakingUpdates -> load data in summary screen only when needed